### PR TITLE
23850 Add getComponentState() and setComponentState() to JavaFxExample

### DIFF
--- a/src/main/java/com/chartiq/finsemble/example/JavaExample.java
+++ b/src/main/java/com/chartiq/finsemble/example/JavaExample.java
@@ -163,11 +163,11 @@ public class JavaExample {
             setDropable();
 
             //GetComponentState
-            JSONArray getComponentStateFields = new JSONArray(){{
+            final JSONArray getComponentStateFields = new JSONArray(){{
                 put("Finsemble_Linker");
                 put("symbol");
             }};
-            JSONObject getComponentStateParam = new JSONObject(){{
+            final JSONObject getComponentStateParam = new JSONObject(){{
                 put("fields", getComponentStateFields);
             }};
             fsbl.getClients().getWindowClient().getComponentState(getComponentStateParam, this::handleGetComponentStateCb);
@@ -279,12 +279,13 @@ public class JavaExample {
             final String symbol = res.has("data") && res.getJSONObject("data").has("data") ?
                     res.getJSONObject("data").getString("data") :
                     "";
-            fsbl.getClients().getWindowClient().setComponentState(new JSONObject(){{put("field", "symbol");put("value", symbol);}}, this::handleSetComponentStateCb);
+            final JSONObject param = new JSONObject() {{
+                put("field", "symbol");
+                put("value", symbol);
+            }};
+            fsbl.getClients().getWindowClient().setComponentState(param, (e, r) -> { });
             Platform.runLater(() -> symbolLabel.setText(symbol));
         }
-    }
-
-    private void handleSetComponentStateCb(JSONObject err, JSONObject res) {
     }
 
     @FXML
@@ -396,22 +397,22 @@ public class JavaExample {
             fsbl.getClients().getLogger().error(err.toString());
         }else{
             //Set subscribe linker channel
-            JSONArray channelToLink = res.getJSONArray("Finsemble_Linker");
-            for(int i=0;i<channelToLink.length();i++){
-                Button tempBtn = (Button) window.getScene().lookup("#"+channelToLink.getString(i)+"Button");
-                Platform.runLater(() -> tempBtn.fire());
-                fsbl.getClients().getLogger().log(channelToLink.getString(i));
+            if (res.has("Finsemble_Linker")) {
+                final JSONArray channelToLink = res.getJSONArray("Finsemble_Linker");
+                for (int i = 0; i < channelToLink.length(); i++) {
+                    Button tempBtn = (Button) window.getScene().lookup("#" + channelToLink.getString(i) + "Button");
+                    Platform.runLater(() -> tempBtn.fire());
+                }
             }
 
             //Set symbol value
-            String symbol = res.getString("symbol");
-            if(!symbol.equals("")){
-                Platform.runLater(() -> symbolLabel.setText(symbol));
+            if(res.has("symbol")) {
+                final String symbol = res.getString("symbol");
+                if (!symbol.equals("")) {
+                    Platform.runLater(() -> symbolLabel.setText(symbol));
+                }
             }
         }
-    }
-
-    private void handleLinkToChannelCb(JSONObject jsonObject, JSONObject jsonObject1) {
     }
 
     private void setDraggable() {

--- a/src/main/java/com/chartiq/finsemble/example/JavaExample.java
+++ b/src/main/java/com/chartiq/finsemble/example/JavaExample.java
@@ -162,6 +162,15 @@ public class JavaExample {
             setDraggable();
             setDropable();
 
+            //GetComponentState
+            JSONArray getComponentStateFields = new JSONArray(){{
+                put("Finsemble_Linker");
+                put("symbol");
+            }};
+            JSONObject getComponentStateParam = new JSONObject(){{
+                put("fields", getComponentStateFields);
+            }};
+            fsbl.getClients().getWindowClient().getComponentState(getComponentStateParam, this::handleGetComponentStateCb);
         } catch (Exception ex) {
             LOGGER.log(Level.SEVERE, "Error initializing Finsemble connection", ex);
             appendMessage("Error initializing Finsemble connection: " + ex.getMessage());
@@ -270,8 +279,12 @@ public class JavaExample {
             final String symbol = res.has("data") && res.getJSONObject("data").has("data") ?
                     res.getJSONObject("data").getString("data") :
                     "";
+            fsbl.getClients().getWindowClient().setComponentState(new JSONObject(){{put("field", "symbol");put("value", symbol);}}, this::handleSetComponentStateCb);
             Platform.runLater(() -> symbolLabel.setText(symbol));
         }
+    }
+
+    private void handleSetComponentStateCb(JSONObject err, JSONObject res) {
     }
 
     @FXML
@@ -376,6 +389,29 @@ public class JavaExample {
         launchComponentButton.setDisable(!enabled);
         linkerPanel.setDisable(!enabled);
         dockingCheckbox.setDisable(!enabled);
+    }
+
+    private void handleGetComponentStateCb(JSONObject err, JSONObject res) {
+        if(err!=null){
+            fsbl.getClients().getLogger().error(err.toString());
+        }else{
+            //Set subscribe linker channel
+            JSONArray channelToLink = res.getJSONArray("Finsemble_Linker");
+            for(int i=0;i<channelToLink.length();i++){
+                Button tempBtn = (Button) window.getScene().lookup("#"+channelToLink.getString(i)+"Button");
+                Platform.runLater(() -> tempBtn.fire());
+                fsbl.getClients().getLogger().log(channelToLink.getString(i));
+            }
+
+            //Set symbol value
+            String symbol = res.getString("symbol");
+            if(!symbol.equals("")){
+                Platform.runLater(() -> symbolLabel.setText(symbol));
+            }
+        }
+    }
+
+    private void handleLinkToChannelCb(JSONObject jsonObject, JSONObject jsonObject1) {
     }
 
     private void setDraggable() {


### PR DESCRIPTION
feat: #28850 [CARD]

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/21/cards/23850/details/)

**Description of change**
Added getComponetState() and setComponenetState() for linked linker channel and symbol data

**Description of testing**
1.  Spawn a JavaFxExample.
2. Link to channel 1 and channel 2 in the JavaFxExample.
3. Send symbol data.
4. Save workspace.
5. Reload workspace.

Expected Result:
1. The linked channel resume back.
2. The symbol data comes back.